### PR TITLE
fix(): set timeout

### DIFF
--- a/ServiceWorker/index.ts
+++ b/ServiceWorker/index.ts
@@ -10,6 +10,8 @@ const httpTrigger: AzureFunction = async function (context: Context, req: HttpRe
   });
   const page = await browser.newPage();
 
+  await page.setDefaultNavigationTimeout(120000);
+
   // empty object that we fill with data below
   let swInfo: any = {};
 


### PR DESCRIPTION
Adds a navigation timeout for Puppeteer so that it waits longer before timing out. This was causing the service worker test to sometimes return a failure even if the site had a service worker if the site took longer to load.