### PR TITLE
fix(): validProtocol temp returns true

### DIFF
--- a/Security/index.ts
+++ b/Security/index.ts
@@ -23,7 +23,7 @@ const httpTrigger: AzureFunction = async function (context: Context, req: HttpRe
     if (securityDetails) {
       const results = {
         "isHTTPS": site.includes('https'),
-        "validProtocol": securityDetails.protocol() === 'TLS 1.2',
+        "validProtocol": true,
         "valid": securityDetails.validTo() <= new Date().getTime()
       };
   


### PR DESCRIPTION
Going to return true for this test temporarily until the new security test (and scoring) is finalized. We were checking for a modern TLS protocol, but we dont yet have good UI for this test that explains that + turns out ALOT of PWAs don't use a modern TLS protocol (or it cant be detected by Chromium for unknown reasons). The test still checks for HTTPS validity and that the HTTPS cert is not expired.