### PR TITLE
Sw timeout fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ If a site has these things then it is a PWA.
 - Theme color 
 - Description 
 - Orientation 
-- At least one maskable icon - modern Androids like Pixel use this. I'd suggest it's a Recommended field.
-- At least one monochrome icon - I understand this has both accessibility implications and user theme/customization implications. Probably either Recommended or Optional.
-- At least one 512x512 or larger square icon - recommended
-  Offline support - something more than a generic 404 error? Given Android's quality bars, I think we could say "recommended" here.
+- At least one maskable icon
+- At least one monochrome icon\
+- At least one 512x512 or larger square icon]
+  Offline support
 
 If a PWA has these then it is a store ready PWA, such as for the Microsoft or Google Play store.
 

--- a/ServiceWorker/index.ts
+++ b/ServiceWorker/index.ts
@@ -75,32 +75,6 @@ const httpTrigger: AzureFunction = async function (context: Context, req: HttpRe
       });
     }
     swInfo['pushReg'] = pushReg;
-
-    // Checking cache
-    // Capture requests during 2nd load.
-    const allRequests = new Map();
-    page.on('request', (req) => {
-      allRequests.set(req.url(), req);
-    });
-
-    // Reload page to pick up any runtime caching done by the service worker.
-    await page.reload({ waitUntil: ['domcontentloaded'] });
-
-    const swRequests = Array.from(allRequests.values());
-
-    let requestChecks = [];
-    swRequests.forEach((req) => {
-      const fromSW =
-        req.response() != null ? req.response().fromServiceWorker() : null;
-      const requestURL = req.response() != null ? req.response().url() : null;
-
-      requestChecks.push({
-        fromSW,
-        requestURL,
-      });
-    });
-
-    swInfo['cache'] = requestChecks;
     
     context.res = {
       status: 200,

--- a/WebManifest/mani-tests.ts
+++ b/WebManifest/mani-tests.ts
@@ -89,7 +89,7 @@ export const checkRelatedApps = (data) => {
 }
 
 export const checkRelatedPref = (data) => {
-  if (data.prefer_related_applications && data.prefer_related_applications !== undefined && data.prefer_related_applications !== null) {
+  if (data.prefer_related_applications !== undefined && data.prefer_related_applications !== null) {
     return true;
   }
   else {


### PR DESCRIPTION
- Merging some changes
- moving the sw cache check out of this function. Because of the multiple page loads that had to happen because of that part of the test, along with the initial page loads to check for a service worker and push registration, this function ends up timing out on larger sites a good bit. This PR removes this part of the check for now (since we weren't really using it in the UI yet) in preparation for improvement and being put in its own function