### PR TITLE
refactor(): only ever load the page once

### DIFF
--- a/Security/index.ts
+++ b/Security/index.ts
@@ -1,31 +1,20 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
-import * as puppeteer from 'puppeteer';
+import loadPage from "../utils/loadPage";
 
 const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
   context.log('Security function processed a request.');
 
   const site = req.query.site;
 
-  const timeout = 120000;
-
-  let browser: puppeteer.Browser;
   try {
-    browser = await puppeteer.launch(
-      {
-        headless: true,
-        args: ['--no-sandbox', '--disable-setuid-sandbox'],
-      }
-    );
-
     let page;
     let pageResponse;
 
     try {
-      page = await browser.newPage();
+      const siteData = await loadPage(site);
 
-      await page.setDefaultNavigationTimeout(timeout);
-
-      pageResponse = await page.goto(site);
+      page = siteData.sitePage;
+      pageResponse = siteData.pageResponse;
     }
     catch (err) {
       context.res = {
@@ -68,11 +57,6 @@ const httpTrigger: AzureFunction = async function (context: Context, req: HttpRe
       body: {
         "error": { error: err, message: err.message }
       }
-    }
-  }
-  finally {
-    if (browser) {
-      await browser.close();
     }
   }
 };

--- a/ServiceWorker/index.ts
+++ b/ServiceWorker/index.ts
@@ -1,23 +1,17 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
-import * as puppeteer from 'puppeteer';
+import loadPage from "../utils/loadPage";
 
 const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
   const url = req.query.site;
 
   const timeout = 120000;
 
-  const browser = await puppeteer.launch({
-    headless: true,
-    args: ['--no-sandbox', '--disable-setuid-sandbox'],
-  });
-  const page = await browser.newPage();
+  const pageData = await loadPage(url);
 
-  await page.setDefaultNavigationTimeout(timeout);
+  const page = pageData.sitePage;
 
   // empty object that we fill with data below
   let swInfo: any = {};
-
-  await page.goto(url, { waitUntil: ['domcontentloaded'] });
 
   try {
     // Check to see if there is a service worker
@@ -72,13 +66,6 @@ const httpTrigger: AzureFunction = async function (context: Context, req: HttpRe
           error: error
         }
       }
-    }
-  } finally {
-    if (page) {
-      await page.close();
-    }
-    if (browser) {
-      await browser.close();
     }
   }
 };

--- a/Site/index.ts
+++ b/Site/index.ts
@@ -31,7 +31,7 @@ const httpTrigger: AzureFunction = async function (
     });
 
     const siteUrl = req.query.site;
-    const { json: manifest, url: manifestUrl } = await getManifest(browser, siteUrl);
+    const { json: manifest, url: manifestUrl } = await getManifest(siteUrl);
     let detectedFormat = <ManifestFormat>manifestTools.detect(manifest);
 
     manifestTools.convertTo(

--- a/WebManifest/index.ts
+++ b/WebManifest/index.ts
@@ -1,5 +1,4 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
-import * as puppeteer from 'puppeteer';
 import { checkBackgroundColor, checkCategories, checkDesc, checkDisplay, checkIcons, checkMaskableIcon, checkName, checkOrientation, checkRating, checkRelatedApps, checkRelatedPref, checkScreenshots, checkShortName, checkStartUrl, checkThemeColor } from './mani-tests';
 import getManifest from "../utils/getManifest";
 
@@ -9,17 +8,9 @@ const httpTrigger: AzureFunction = async function (context: Context, req: HttpRe
   context.log('Web Manifest function processed a request.');
 
   const site = req.query.site;
-
-  let browser: puppeteer.Browser;
   try {
-    browser = await puppeteer.launch(
-      {
-        headless: true,
-        args: ['--no-sandbox', '--disable-setuid-sandbox'],
-      }
-    );
 
-    const maniData = await getManifest(browser, site);
+    const maniData = await getManifest(site);
 
     if (maniData) {
       const results = {
@@ -63,10 +54,6 @@ const httpTrigger: AzureFunction = async function (context: Context, req: HttpRe
         "error": { error: err, message: err.message }
       },
     };
-  } finally {
-    if (browser) {
-      await browser.close();
-    }
   }
 };
 

--- a/utils/getManifest.ts
+++ b/utils/getManifest.ts
@@ -1,6 +1,6 @@
-import { Browser } from "puppeteer";
 import fetch from "node-fetch";
 import ExceptionOf, { ExceptionType } from "./Exception";
+import loadPage from "./loadPage";
 
 export type Manifest = any;
 export interface ManifestInformation {
@@ -9,15 +9,12 @@ export interface ManifestInformation {
 }
 
 export default async function getManifest(
-  browser: Browser,
   site: string
 ): Promise<ManifestInformation> {
   try {
-    const sitePage = await browser.newPage();
+    const siteData = await loadPage(site);
 
-    await sitePage.goto(site);
-
-    const manifestUrl = await sitePage.$eval(
+    const manifestUrl = await siteData.sitePage.$eval(
       "link[rel=manifest]",
       (el: HTMLAnchorElement) => el.href
     );

--- a/utils/loadPage.ts
+++ b/utils/loadPage.ts
@@ -1,0 +1,57 @@
+import * as puppeteer from 'puppeteer';
+
+export default async function loadPage(site: string): Promise<{sitePage: puppeteer.Page, pageResponse: puppeteer.Response, browser: puppeteer.Browser}> {
+  let browser: puppeteer.Browser;
+  let sitePage: puppeteer.Page;
+  let pageResponse: puppeteer.Response;
+
+  const timeout = 120000;
+
+  if (sitePage && pageResponse) {
+    return {
+      sitePage: sitePage,
+      pageResponse: pageResponse,
+      browser: browser
+    };
+  }
+  else {
+    try {
+      browser = await puppeteer.launch(
+        {
+          headless: true,
+          args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        }
+      );
+
+      sitePage = await browser.newPage();
+
+      await sitePage.setDefaultNavigationTimeout(timeout);
+
+      pageResponse =  await sitePage.goto(site, { waitUntil: ['domcontentloaded'] });
+
+      await handleEvent(sitePage);
+
+      return {
+        sitePage: sitePage,
+        pageResponse: pageResponse,
+        browser: browser
+      };
+    }
+    catch (err) {
+      return err || err.message;
+    }
+  }
+}
+
+async function handleEvent(sitePage): Promise<void> {
+  return new Promise((resolve, reject) => {
+    try {
+      sitePage.once('load', () => {
+        resolve();
+      })
+    }
+    catch (err) {
+      reject(err);
+    }
+  })
+}


### PR DESCRIPTION
refactor: 

- move loading the page out to a utils function
- ensure we only ever load the page once during any test

This should lower timeout errors even further